### PR TITLE
Fixed numerous CF & C memory leaks

### DIFF
--- a/WebpQuickLook/GenerateThumbnailForURL.c
+++ b/WebpQuickLook/GenerateThumbnailForURL.c
@@ -19,17 +19,20 @@ OSStatus GenerateThumbnailForURL(void *thisInterface, QLThumbnailRequestRef thum
     // get posix path and convert it to C string then we can get data from file with simple C operation.
     // Sometimes CoreFoundation is pain in the ass. I don't want to use it to get byte data
     
-    CFStringRef path = CFURLCopyPath(url);
-    path = CFURLCreateStringByReplacingPercentEscapes(kCFAllocatorDefault, path, CFSTR(""));
+    CFStringRef rawPath = CFURLCopyPath(url);
+    CFStringRef path = CFURLCreateStringByReplacingPercentEscapes(kCFAllocatorDefault, rawPath, CFSTR(""));
+    CFRelease(rawPath);
     CFIndex length  = CFStringGetLength(path);
     CFIndex max = CFStringGetMaximumSizeForEncoding(length, kCFStringEncodingUTF8);
     
     char* c_path = (char*)malloc(max);
     CFStringGetCString(path, c_path, max, kCFStringEncodingUTF8);
+    CFRelease(path);
     
     // let 's do the reading and decoding with libwebp
     
     FILE *file = fopen(c_path, "r");
+    free(c_path);
     
     if (file != NULL) {
         
@@ -128,10 +131,14 @@ OSStatus GenerateThumbnailForURL(void *thisInterface, QLThumbnailRequestRef thum
         
         CGDataProviderRef provider = CGDataProviderCreateWithData(NULL, rgbData, width*height*4, NULL);
         
-        CGImageRef image =  CGImageCreate(width, height, 8, 32, width * 4, CGColorSpaceCreateDeviceRGB(), kCGImageAlphaLast, provider, NULL, false, kCGRenderingIntentDefault);
-        
+        CGColorSpaceRef deviceRGBColorSpace = CGColorSpaceCreateDeviceRGB();
+        CGImageRef image =  CGImageCreate(width, height, 8, 32, width * 4, deviceRGBColorSpace, kCGImageAlphaLast, provider, NULL, false, kCGRenderingIntentDefault);
         
         CGContextDrawImage(ctx, CGRectMake(0, 0, width, height), image);
+        
+        CGDataProviderRelease(provider);
+        CGColorSpaceRelease(deviceRGBColorSpace);
+        CGImageRelease(image);
         
         CGContextFlush(ctx);
         


### PR DESCRIPTION
Added the `CF…Release()` & `free()` calls necessary when using non-ARC plain-C stuff like CoreFoundation & malloc.